### PR TITLE
Fix get_input_source when the VCP sets the reserved byte.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Change Log
 ##########
 
+`2.4.1`_ 2021-04-10
+*******************
+
+Fixed
+=====
+- Fixed ``get_input_source`` failing for monitors that set the reserved byte.
+- Fixed ``get_input_source`` returning a ``str`` instead of a ``InputSource`` as
+  the type hint indicated.
+
 `2.4.0`_ 2021-03-14
 *******************
 
@@ -42,6 +51,7 @@ Added
 =====
 - Added a changelog.
 
+.. _2.4.1: https://github.com/newAM/monitorcontrol/releases/tag/2.4.1
 .. _2.4.0: https://github.com/newAM/monitorcontrol/releases/tag/2.4.0
 .. _2.3.0: https://github.com/newAM/monitorcontrol/releases/tag/2.3.0
 .. _2.2.0: https://github.com/newAM/monitorcontrol/releases/tag/2.2.0

--- a/monitorcontrol/monitorcontrol.py
+++ b/monitorcontrol/monitorcontrol.py
@@ -357,8 +357,8 @@ class Monitor:
             VCPError: Failed to get input source from the VCP.
         """
         code = vcp.VCPCode("input_select")
-        value = self._get_vcp_feature(code)
-        return InputSource(value).name
+        value = self._get_vcp_feature(code) & 0xFF
+        return InputSource(value)
 
     def set_input_source(self, value: Union[int, str, InputSource]):
         """


### PR DESCRIPTION
Closes #59 