### PR TITLE
Create `WindowsVCP` for each physical monitor instead of logical

### DIFF
--- a/monitorcontrol/vcp/vcp_windows.py
+++ b/monitorcontrol/vcp/vcp_windows.py
@@ -42,7 +42,7 @@ if sys.platform == "win32":
             self.description = description
 
         def __del__(self):
-            WindowsVCP._DestroyPhysicalMonitor(self.handle)
+            WindowsVCP._destroy_physical_monitor(self.handle)
 
         def __enter__(self):
             pass
@@ -230,7 +230,10 @@ if sys.platform == "win32":
             )
 
         @staticmethod
-        def _DestroyPhysicalMonitor(handle: HANDLE) -> None:
+        def _destroy_physical_monitor(handle: HANDLE) -> None:
+            """
+            Calls the Windows `DestroyPhysicalMonitor` API in Python-friendly form.
+            """
             try:
                 if not ctypes.windll.dxva2.DestroyPhysicalMonitor(handle):
                     raise VCPError(

--- a/monitorcontrol/vcp/vcp_windows.py
+++ b/monitorcontrol/vcp/vcp_windows.py
@@ -151,12 +151,7 @@ if sys.platform == "win32":
             return cap_string.value.decode("ascii")
 
         @staticmethod
-        def _get_physical_monitors(
-            get_hmonitors: Callable[[], List[HMONITOR]],
-            physical_monitors_from_hmonitor: Callable[
-                [HMONITOR], List[Tuple[HANDLE, str]]
-            ],
-        ) -> List[Tuple[HANDLE, str]]:
+        def _get_physical_monitors() -> List[Tuple[HANDLE, str]]:
             """
             Returns a list of physical monitors.
 
@@ -165,8 +160,10 @@ if sys.platform == "win32":
             """
             return (
                 physical_monitor
-                for hmonitor in get_hmonitors()
-                for physical_monitor in physical_monitors_from_hmonitor(hmonitor)
+                for hmonitor in WindowsVCP._get_hmonitors()
+                for physical_monitor in WindowsVCP._physical_monitors_from_hmonitor(
+                    hmonitor
+                )
             )
 
         @staticmethod
@@ -252,9 +249,7 @@ if sys.platform == "win32":
         Raises:
             VCPError: Failed to enumerate VCPs.
         """
-        physical_monitors = WindowsVCP._get_physical_monitors(
-            WindowsVCP._get_hmonitors, WindowsVCP._physical_monitors_from_hmonitor
-        )
+        physical_monitors = WindowsVCP._get_physical_monitors()
         return list(
             WindowsVCP(handle, description)
             for (handle, description) in physical_monitors

--- a/monitorcontrol/vcp/vcp_windows.py
+++ b/monitorcontrol/vcp/vcp_windows.py
@@ -1,6 +1,6 @@
 from .vcp_abc import VCP, VCPError
 from types import TracebackType
-from typing import Callable, List, Optional, Tuple, Type
+from typing import Iterator, List, Optional, Tuple, Type
 import ctypes
 import logging
 import sys
@@ -151,12 +151,9 @@ if sys.platform == "win32":
             return cap_string.value.decode("ascii")
 
         @staticmethod
-        def _get_physical_monitors() -> List[Tuple[HANDLE, str]]:
+        def _get_physical_monitors() -> Iterator[Tuple[HANDLE, str]]:
             """
             Returns a list of physical monitors.
-
-            Underlying Windows APIs are given as `Callable`s to make this
-            function testable.
             """
             return (
                 physical_monitor
@@ -192,7 +189,7 @@ if sys.platform == "win32":
         @staticmethod
         def _physical_monitors_from_hmonitor(
             hmonitor: HMONITOR,
-        ) -> List[Tuple[HANDLE, str]]:
+        ) -> Iterator[Tuple[HANDLE, str]]:
             """
             Calls the Windows `GetPhysicalMonitorsFromHMONITOR` API in Python-friendly form.
             """

--- a/monitorcontrol/vcp/vcp_windows.py
+++ b/monitorcontrol/vcp/vcp_windows.py
@@ -156,7 +156,7 @@ if sys.platform == "win32":
             physical_monitors_from_hmonitor: Callable[
                 [HMONITOR], List[Tuple[HANDLE, str]]
             ],
-        ):
+        ) -> List[Tuple[HANDLE, str]]:
             """
             Returns a list of physical monitors.
 

--- a/monitorcontrol/vcp/vcp_windows.py
+++ b/monitorcontrol/vcp/vcp_windows.py
@@ -224,7 +224,7 @@ if sys.platform == "win32":
                     )
             except OSError as e:
                 raise VCPError("failed to open physical monitor handle") from e
-            return list(
+            return (
                 [physical_monitor.handle, physical_monitor.description]
                 for physical_monitor in physical_monitors
             )

--- a/monitorcontrol/vcp/vcp_windows.py
+++ b/monitorcontrol/vcp/vcp_windows.py
@@ -170,7 +170,7 @@ if sys.platform == "win32":
             )
 
         @staticmethod
-        def _EnumDisplayMonitors() -> List[HMONITOR]:
+        def _get_hmonitors() -> List[HMONITOR]:
             """
             Calls the Windows `EnumDisplayMonitors` API in Python-friendly form.
             """
@@ -193,7 +193,7 @@ if sys.platform == "win32":
             return hmonitors
 
         @staticmethod
-        def _GetPhysicalMonitorsFromHMONITOR(
+        def _physical_monitors_from_hmonitor(
             hmonitor: HMONITOR,
         ) -> List[Tuple[HANDLE, str]]:
             """
@@ -250,7 +250,7 @@ if sys.platform == "win32":
             VCPError: Failed to enumerate VCPs.
         """
         physical_monitors = WindowsVCP._get_physical_monitors(
-            WindowsVCP._EnumDisplayMonitors, WindowsVCP._GetPhysicalMonitorsFromHMONITOR
+            WindowsVCP._get_hmonitors, WindowsVCP._physical_monitors_from_hmonitor
         )
         return list(
             WindowsVCP(handle, description)

--- a/tests/test_windows_vcp.py
+++ b/tests/test_windows_vcp.py
@@ -1,0 +1,28 @@
+import pytest
+import sys
+from monitorcontrol.vcp.vcp_windows import WindowsVCP
+
+
+if sys.platform == "win32":
+
+    @pytest.mark.parametrize(
+        "input,expected",
+        [
+            [[1], ["1-0"]],
+            [[2], ["2-0", "2-1"]],
+            [[1, 2], ["1-0", "2-0", "2-1"]],
+            [[1, 3], ["1-0", "3-0", "3-1", "3-2"]],
+        ],
+    )
+    def test_get_physical_monitors(input, expected):
+        physical_monitors = {
+            1: ["1-0"],
+            2: ["2-0", "2-1"],
+            3: ["3-0", "3-1", "3-2"],
+        }
+        result = list(
+            WindowsVCP._get_physical_monitors(
+                lambda: input, lambda hmonitor: physical_monitors.get(hmonitor)
+            )
+        )
+        assert result == expected

--- a/tests/test_windows_vcp.py
+++ b/tests/test_windows_vcp.py
@@ -1,9 +1,9 @@
 import pytest
 import sys
-from monitorcontrol.vcp.vcp_windows import WindowsVCP
 
 
 if sys.platform == "win32":
+    from monitorcontrol.vcp.vcp_windows import WindowsVCP
 
     @pytest.mark.parametrize(
         "input,expected",

--- a/tests/test_windows_vcp.py
+++ b/tests/test_windows_vcp.py
@@ -1,5 +1,6 @@
 import pytest
 import sys
+from unittest.mock import patch
 
 
 if sys.platform == "win32":
@@ -14,15 +15,20 @@ if sys.platform == "win32":
             [[1, 3], ["1-0", "3-0", "3-1", "3-2"]],
         ],
     )
-    def test_get_physical_monitors(input, expected):
+    @patch("monitorcontrol.vcp.vcp_windows.WindowsVCP._get_hmonitors")
+    @patch("monitorcontrol.vcp.vcp_windows.WindowsVCP._physical_monitors_from_hmonitor")
+    def test_get_physical_monitors(
+        physical_monitors_from_hmonitor, get_hmonitors, input, expected
+    ):
+        get_hmonitors.return_value = input
         physical_monitors = {
             1: ["1-0"],
             2: ["2-0", "2-1"],
             3: ["3-0", "3-1", "3-2"],
         }
-        result = list(
-            WindowsVCP._get_physical_monitors(
-                lambda: input, lambda hmonitor: physical_monitors.get(hmonitor)
-            )
+        physical_monitors_from_hmonitor.side_effect = (
+            lambda hmonitor: physical_monitors.get(hmonitor)
         )
+        print(WindowsVCP._get_hmonitors())
+        result = list(WindowsVCP._get_physical_monitors())
         assert result == expected

--- a/tests/test_windows_vcp.py
+++ b/tests/test_windows_vcp.py
@@ -29,6 +29,5 @@ if sys.platform == "win32":
         physical_monitors_from_hmonitor.side_effect = (
             lambda hmonitor: physical_monitors.get(hmonitor)
         )
-        print(WindowsVCP._get_hmonitors())
         result = list(WindowsVCP._get_physical_monitors())
         assert result == expected

--- a/tests/test_windows_vcp.py
+++ b/tests/test_windows_vcp.py
@@ -7,7 +7,7 @@ if sys.platform == "win32":
     from monitorcontrol.vcp.vcp_windows import WindowsVCP
 
     @pytest.mark.parametrize(
-        "input,expected",
+        "monitor_input, expected",
         [
             [[1], ["1-0"]],
             [[2], ["2-0", "2-1"]],
@@ -18,9 +18,9 @@ if sys.platform == "win32":
     @patch("monitorcontrol.vcp.vcp_windows.WindowsVCP._get_hmonitors")
     @patch("monitorcontrol.vcp.vcp_windows.WindowsVCP._physical_monitors_from_hmonitor")
     def test_get_physical_monitors(
-        physical_monitors_from_hmonitor, get_hmonitors, input, expected
+        physical_monitors_from_hmonitor, get_hmonitors, monitor_input, expected
     ):
-        get_hmonitors.return_value = input
+        get_hmonitors.return_value = monitor_input
         physical_monitors = {
             1: ["1-0"],
             2: ["2-0", "2-1"],


### PR DESCRIPTION
This should fix #300. I have 4 monitors, but I don't have an environment that can reproduces the issue (i.e., multiple physical monitors for a logical monitor). The fix is verified only in my environment and in the unit tests.